### PR TITLE
Add CMake build system using SFML FetchContent

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,25 @@
+cmake_minimum_required(VERSION 3.20)
+
+project(cpp_chess_engine LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+include(FetchContent)
+
+FetchContent_Declare(
+    sfml
+    GIT_REPOSITORY https://github.com/SFML/SFML.git
+    GIT_TAG 2.6.1
+)
+
+FetchContent_MakeAvailable(sfml)
+
+file(GLOB SOURCE_FILES "cpp_chess_engine/*.cpp")
+
+add_executable(cpp_chess_engine ${SOURCE_FILES})
+
+target_include_directories(cpp_chess_engine PRIVATE cpp_chess_engine)
+
+target_link_libraries(cpp_chess_engine PRIVATE sfml-graphics sfml-window sfml-system)
+

--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
 # cpp_chess_engine
+
+## Build
+
+This project uses [CMake](https://cmake.org/) and automatically downloads its SFML dependency.
+To build the project you need a C++ compiler and CMake installed on your system.
+
+### Linux/macOS
+```bash
+./scripts/build_linux.sh
+```
+
+### Windows
+```powershell
+.\scripts\build_windows.ps1
+```

--- a/scripts/build_linux.sh
+++ b/scripts/build_linux.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -e
+cmake -S . -B build
+cmake --build build

--- a/scripts/build_windows.ps1
+++ b/scripts/build_windows.ps1
@@ -1,0 +1,2 @@
+cmake -S . -B build
+cmake --build build


### PR DESCRIPTION
## Summary
- build using CMake with FetchContent-based SFML dependency
- add build scripts for Linux and Windows
- document the new CMake-based build workflow

## Testing
- `./scripts/build_linux.sh` *(fails: unable to clone SFML repository)*

------
https://chatgpt.com/codex/tasks/task_e_688e674eb9488328b1ac286cf6d8779d