### PR TITLE
docs: note libudev requirement for SFML

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@ To build the project you need a C++ compiler and CMake installed on your system.
 ./scripts/build_linux.sh
 ```
 
+On Linux, SFML additionally requires the `libudev` headers. You can install them with:
+
+```bash
+sudo apt install libudev-dev
+```
+
 ### Windows
 ```powershell
 .\scripts\build_windows.ps1


### PR DESCRIPTION
## Summary
- document libudev development headers requirement for SFML on Linux

## Testing
- `./scripts/build_linux.sh` *(fails: Failed to clone repository 'https://github.com/SFML/SFML.git')*

------
https://chatgpt.com/codex/tasks/task_e_688e79b8a6e483289ee9c4f1b52ccc9a