### PR TITLE
Clarify build script usage and improve dependency checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ This project uses [CMake](https://cmake.org/) and automatically downloads its SF
 To build the project you need a C++ compiler and CMake installed on your system.
 
 ### Linux/macOS
+Run the build script directly (do not source it):
+
 ```bash
 ./scripts/build_linux.sh
 ```

--- a/scripts/build_linux.sh
+++ b/scripts/build_linux.sh
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
-set -e
-cmake -S . -B build
-cmake --build build
+
+if ! command -v cmake >/dev/null 2>&1; then
+  echo "Error: cmake is not installed. Please install cmake and try again." >&2
+  exit 1
+fi
+
+cmake -S . -B build || { echo "CMake configuration failed" >&2; exit 1; }
+cmake --build build || { echo "Build failed" >&2; exit 1; }


### PR DESCRIPTION
## Summary
- warn Linux/macOS users to run build script directly rather than sourcing
- add cmake dependency check and clearer error messages in build_linux.sh

## Testing
- `./scripts/build_linux.sh` *(fails: Failed to clone repository: 'https://github.com/SFML/SFML.git')*
- `shellcheck scripts/build_linux.sh` *(fails: command not found)*
- `apt-get update` *(fails: The repository 'http://security.ubuntu.com/ubuntu noble-security InRelease' is not signed.)*


------
https://chatgpt.com/codex/tasks/task_e_688e79b91930832897ffca1ac97f8873