### PR TITLE
Make bit ops portable

### DIFF
--- a/cpp_chess_engine/BishopValidator.cpp
+++ b/cpp_chess_engine/BishopValidator.cpp
@@ -90,7 +90,7 @@ Bitboard findMagicBishop(int square, int relevantBits) {
     for (int trial = 0; trial < 100000000; trial++) {
         magicCandidate = randomUint64FewBits(rng);
         // Heuristic check similar to the rook version; adjust the threshold as needed.
-        if (__popcnt64((magicCandidate * mask) & 0xFF00000000000000ULL) < 6)
+        if (popcount((magicCandidate * mask) & 0xFF00000000000000ULL) < 6)
             continue;
 
         std::fill(used.begin(), used.end(), 0ULL);
@@ -128,7 +128,7 @@ void BishopValidator::initBishopMagics() {
     for (int square = 0; square < 64; square++) {
         Magic& m = bishopMagics[square];
         m.mask = bishopOccupancyMask(square);
-        int relevantBits = __popcnt64(m.mask);
+        int relevantBits = popcount(m.mask);
         int occupancyVariations = 1 << relevantBits;
         m.shift = 64 - relevantBits;
         m.attacks = new Bitboard[occupancyVariations];

--- a/cpp_chess_engine/BitOps.cpp
+++ b/cpp_chess_engine/BitOps.cpp
@@ -5,30 +5,43 @@
 #include <ctime>
 #include <iostream>
 #include <bitset>
-#ifdef _WIN64
+#if defined(_MSC_VER)
 #include <intrin.h>
 #endif
 
 // Scans the bitboard from least significant bit to most significant bit
 // and returns the index of the first set bit.
 int bitScanForward(Bitboard bb) {
+#if defined(_MSC_VER)
+#if defined(_WIN64)
     unsigned long index;
-#ifdef _WIN64
     _BitScanForward64(&index, bb);
+    return static_cast<int>(index);
 #else
+    unsigned long index;
     if (static_cast<uint32_t>(bb) != 0) {
-        // Note: on non-Windows systems you might use __builtin_ctzll if available.
         _BitScanForward(&index, static_cast<uint32_t>(bb));
-    }
-    else {
+        return static_cast<int>(index);
+    } else {
         _BitScanForward(&index, static_cast<uint32_t>(bb >> 32));
-        index += 32;
+        return static_cast<int>(index + 32);
     }
 #endif
-    return static_cast<int>(index);
+#else
+    return static_cast<int>(__builtin_ctzll(bb));
+#endif
 }
 
-// Sets occupancy given an index into the mask’s bit count.
+// Counts the number of set bits in a bitboard.
+int popcount(Bitboard bb) {
+#if defined(_MSC_VER)
+    return static_cast<int>(__popcnt64(bb));
+#else
+    return __builtin_popcountll(bb);
+#endif
+}
+
+// Sets occupancy given an index into the masks bit count.
 Bitboard setOccupancy(int index, int bitsInMask, Bitboard mask) {
     Bitboard occupancy = 0ULL;
     for (int i = 0; i < bitsInMask; i++) {
@@ -42,7 +55,7 @@ Bitboard setOccupancy(int index, int bitsInMask, Bitboard mask) {
 
 // Generates all occupancy variations for a given mask.
 std::vector<Bitboard> generateOccupancies(Bitboard mask) {
-    int bits = __popcnt64(mask);  // Use __popcnt64 on MSVC or __builtin_popcountll on GCC/Clang.
+    int bits = popcount(mask);
     int occupancyVariations = 1 << bits;
     std::vector<Bitboard> occupancies(occupancyVariations);
     for (int index = 0; index < occupancyVariations; index++) {

--- a/cpp_chess_engine/BitOps.hpp
+++ b/cpp_chess_engine/BitOps.hpp
@@ -10,7 +10,10 @@
 // and returns the index of the first set bit.
 int bitScanForward(Bitboard bb);
 
-// Sets occupancy given an index into the mask’s bits.
+// Counts the number of set bits in a bitboard.
+int popcount(Bitboard bb);
+
+// Sets occupancy given an index into the masks bits.
 Bitboard setOccupancy(int index, int bitsInMask, Bitboard mask);
 
 // Generates all occupancy variations for a given mask.

--- a/cpp_chess_engine/ChessBoard.cpp
+++ b/cpp_chess_engine/ChessBoard.cpp
@@ -5,7 +5,7 @@
 #include "RookValidator.hpp"
 #include "BishopValidator.hpp"
 #include "Constants.hpp"
-#include <intrin.h>
+#include "BitOps.hpp"
 
 
 RookValidator rookValidator;
@@ -213,10 +213,7 @@ void ChessBoard::syncBoardWithBitboards() {
     for (int i = 0; i < 12; ++i) {
         Bitboard bb = bitboards[i];
         while (bb) {
-            unsigned long index;
-            // _BitScanForward64 finds the index of the least significant set bit.
-            _BitScanForward64(&index, bb);
-            int pos = static_cast<int>(index);
+            int pos = bitScanForward(bb);
             // Convert bit index to board coordinates.
             int row = 7 - (pos / 8);
             int col = pos % 8;
@@ -625,7 +622,7 @@ bool ChessBoard::movePiece(const int& fromRow, const int& fromCol, const int& ne
             // Remove the captured pawn from the square behind the en passant target.     
             board[newRow - rankEPAdjustment][newCol] = '.';       
 			std::cout << "eraesed: " << newRow + rankEPAdjustment << " " << newCol << "\n";
-            // For bitboards, use the opponent’s pawn index:       
+            // For bitboards, use the opponentÂ’s pawn index:       
             int oppPawnIdx = whiteToMove ? b_pawn_idx : w_pawn_idx;       
             int capture_idx = get_bitindex(newRow - rankEPAdjustment, newCol);       
             bitboards[oppPawnIdx] &= ~(1ULL << capture_idx);   
@@ -638,7 +635,7 @@ bool ChessBoard::movePiece(const int& fromRow, const int& fromCol, const int& ne
             enPassant = 0ULL;
         }
           
-            // Update the moving pawn’s bitboard normally.       
+            // Update the moving pawnÂ’s bitboard normally.       
             //printBitboardBoard(bitboards[piece_to_idx[piece]]);
             if (occupying_piece != '.') bitboards[piece_to_idx[occupying_piece]] &= ~(1ULL << to_idx);
 

--- a/cpp_chess_engine/RookValidator.cpp
+++ b/cpp_chess_engine/RookValidator.cpp
@@ -13,7 +13,9 @@
 
 
 #include <array>
+#if defined(_MSC_VER)
 #include <intrin.h>
+#endif
 
 
 
@@ -73,7 +75,7 @@ Bitboard findMagic(int square, int relevantBits, bool isRook) {
     std::vector<Bitboard> used(4096); // max possible size for rook is 4096
     for (int trial = 0; trial < 100000000; trial++) {
         magicCandidate = randomUint64FewBits(rng);
-        if (__popcnt64((magicCandidate * rookOccupancyMask(square)) & 0xFF00000000000000ULL) < 6)
+        if (popcount((magicCandidate * rookOccupancyMask(square)) & 0xFF00000000000000ULL) < 6)
             continue;
         std::fill(used.begin(), used.end(), 0ULL);
         bool collision = false;
@@ -109,7 +111,7 @@ void RookValidator::initRookMagics() {
     for (int square = 0; square < 64; square++) {
         Magic& m = rookMagics[square];
         m.mask = rookOccupancyMask(square);
-        int relevantBits = __popcnt64(m.mask);
+        int relevantBits = popcount(m.mask);
         int occupancyVariations = 1 << relevantBits;
         m.shift = 64 - relevantBits;
         m.attacks = new Bitboard[occupancyVariations];


### PR DESCRIPTION
## Summary
- Add cross-platform `bitScanForward` and `popcount` helpers
- Replace Windows-only intrinsics in bishop and rook magic generation
- Use portable bit scanning in board synchronisation

## Testing
- `./scripts/build_linux.sh` *(fails: CONNECT tunnel failed, response 403 when cloning SFML)*

------
https://chatgpt.com/codex/tasks/task_e_688e806f02c08328a9994a757aff0893