### PR TITLE
Fix optional usage and remove inline declarations

### DIFF
--- a/cpp_chess_engine/BishopValidator.cpp
+++ b/cpp_chess_engine/BishopValidator.cpp
@@ -153,7 +153,7 @@ Bitboard BishopValidator::getAttacks(int square, const ChessBoard& board) const 
 
 
 // Retrieves bishop attack bitboard from precomputed magic table.
-inline Bitboard BishopValidator::getBishopAttacks(int square, Bitboard occupancy) const {
+Bitboard BishopValidator::getBishopAttacks(int square, Bitboard occupancy) const {
     occupancy &= bishopMagics[square].mask;
     occupancy *= bishopMagics[square].magic;
     occupancy >>= bishopMagics[square].shift;

--- a/cpp_chess_engine/BishopValidator.hpp
+++ b/cpp_chess_engine/BishopValidator.hpp
@@ -17,7 +17,7 @@ public:
     bool validate(int from_idx, Bitboard target, const ChessBoard& board) const;
 
     Bitboard getAttacks(int square, const ChessBoard& board) const;
-    inline Bitboard getBishopAttacks(int square, Bitboard occupancy) const;
+    Bitboard getBishopAttacks(int square, Bitboard occupancy) const;
 private:
     std::array<Bitboard, 64> bishopMoves;
     Magic bishopMagics[64];

--- a/cpp_chess_engine/ChessBoard.cpp
+++ b/cpp_chess_engine/ChessBoard.cpp
@@ -190,10 +190,6 @@ int ChessBoard::get_bitindex(int row, int col)  {
     return (7 - row) * 8 + col;
 }
 
-int get_bitindex(int row, int col) {
-    // Map board coordinates to a bitboard index.
-    return (7 - row) * 8 + col;
-}
 
 
 

--- a/cpp_chess_engine/GUIBoard.cpp
+++ b/cpp_chess_engine/GUIBoard.cpp
@@ -1,6 +1,7 @@
 #include "GUIBoard.hpp"
 #include "ChessBoard.hpp"
 #include "BitOps.hpp"
+#include <optional>
 
 GUIBoard::GUIBoard(ChessBoard& cb) : cb(cb) {
     initialize();  // Additional setup function
@@ -62,18 +63,16 @@ void GUIBoard::createSFMLWindow() {
 
     while (window.isOpen()) {
         // --- Event Handling ---
-        while (const std::optional<sf::Event> ev = window.pollEvent()) {
-            if (!ev.has_value()) break;
-            const sf::Event& event = *ev;
-
-            if (event.is<sf::Event::Closed>()) {
+        sf::Event event;
+        while (window.pollEvent(event)) {
+            if (event.type == sf::Event::Closed) {
                 window.close();
             }
-            else if (auto mb = event.getIf<sf::Event::MouseButtonPressed>()) {
-                int col = mb->position.x / cellSize;
-                int row = mb->position.y / cellSize;
+            else if (event.type == sf::Event::MouseButtonPressed) {
+                int col = event.mouseButton.x / cellSize;
+                int row = event.mouseButton.y / cellSize;
 
-                if (mb->button == sf::Mouse::Button::Left) {
+                if (event.mouseButton.button == sf::Mouse::Left) {
                     // clear any attack highlights on a normal (left) click
                     attackSourceSquare.reset();
 
@@ -96,7 +95,7 @@ void GUIBoard::createSFMLWindow() {
                         }
                     }
                 }
-                else if (mb->button == sf::Mouse::Button::Right) {
+                else if (event.mouseButton.button == sf::Mouse::Right) {
                     sf::Vector2i clicked{ col, row };
                     // toggle attack highlight on repeated right-click
                     if (attackSourceSquare && *attackSourceSquare == clicked) {

--- a/cpp_chess_engine/GetBitIndex.cpp
+++ b/cpp_chess_engine/GetBitIndex.cpp
@@ -1,4 +1,0 @@
-int get_bitindex(int row, int col) {
-    // Map board coordinates to a bitboard index.
-    return (7 - row) * 8 + col;
-}

--- a/cpp_chess_engine/RookValidator.cpp
+++ b/cpp_chess_engine/RookValidator.cpp
@@ -134,7 +134,7 @@ Bitboard RookValidator::getAttacks(int square, const ChessBoard& board) const {
     return possibleMoves;
 }
 
-inline Bitboard RookValidator::getRookAttacks(int square, Bitboard occupancy) const {
+Bitboard RookValidator::getRookAttacks(int square, Bitboard occupancy) const {
     occupancy &= rookMagics[square].mask;
     occupancy *= rookMagics[square].magic;
     occupancy >>= rookMagics[square].shift;

--- a/cpp_chess_engine/RookValidator.hpp
+++ b/cpp_chess_engine/RookValidator.hpp
@@ -18,8 +18,8 @@ public:
     bool validate(int from_idx, int to_idx, const ChessBoard& board) const override;
     bool validate(int from_idx, Bitboard target, const ChessBoard& board) const;
 
-	Bitboard getAttacks(int square, const ChessBoard& board) const;
-    inline Bitboard getRookAttacks(int square, Bitboard occupancy) const;
+        Bitboard getAttacks(int square, const ChessBoard& board) const;
+    Bitboard getRookAttacks(int square, Bitboard occupancy) const;
 
 private:
     std::array<Bitboard, 64> rookMoves;


### PR DESCRIPTION
## Summary
- use `<optional>` in GUI and rewrite event loop for SFML 2 style
- remove misleading inline declarations from bishop and rook validators

## Testing
- `./scripts/build_linux.sh` *(fails: Failed to clone repository: 'https://github.com/SFML/SFML.git')*
- `apt-get update` *(fails: repository 'http://security.ubuntu.com/ubuntu noble-security InRelease' is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_688e86928cc48328ae4644bd7056f129