### PR TITLE
Fix duplicate get_bitindex function causing linker error

### DIFF
--- a/cpp_chess_engine/ChessBoard.cpp
+++ b/cpp_chess_engine/ChessBoard.cpp
@@ -190,10 +190,6 @@ int ChessBoard::get_bitindex(int row, int col)  {
     return (7 - row) * 8 + col;
 }
 
-int get_bitindex(int row, int col) {
-    // Map board coordinates to a bitboard index.
-    return (7 - row) * 8 + col;
-}
 
 
 

--- a/cpp_chess_engine/GetBitIndex.cpp
+++ b/cpp_chess_engine/GetBitIndex.cpp
@@ -1,4 +1,0 @@
-int get_bitindex(int row, int col) {
-    // Map board coordinates to a bitboard index.
-    return (7 - row) * 8 + col;
-}


### PR DESCRIPTION
## Summary
- remove redundant global `get_bitindex` definition to avoid multiple symbol definitions
- rely on `ChessBoard::get_bitindex` for board coordinate mapping

## Testing
- `./scripts/build_linux.sh` *(fails: unable to clone SFML dependency)*

------
https://chatgpt.com/codex/tasks/task_e_688e88bba57c8328bd2495282d57e279