### PR TITLE
Add portable popcount function and unit test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,3 +23,9 @@ target_include_directories(cpp_chess_engine PRIVATE cpp_chess_engine)
 
 target_link_libraries(cpp_chess_engine PRIVATE sfml-graphics sfml-window sfml-system)
 
+enable_testing()
+
+add_executable(popcount_test tests/popcount_test.cpp cpp_chess_engine/BitOps.cpp)
+target_include_directories(popcount_test PRIVATE cpp_chess_engine)
+add_test(NAME popcount_test COMMAND popcount_test)
+

--- a/cpp_chess_engine/BitOps.cpp
+++ b/cpp_chess_engine/BitOps.cpp
@@ -7,6 +7,7 @@
 #include <bitset>
 #if defined(_MSC_VER)
 #include <intrin.h>
+#include <nmmintrin.h>
 #endif
 
 // Scans the bitboard from least significant bit to most significant bit
@@ -32,12 +33,34 @@ int bitScanForward(Bitboard bb) {
 #endif
 }
 
-// Counts the number of set bits in a bitboard.
+// Counts the number of set bits in a bitboard using the most efficient
+// implementation available for the current platform.
 int popcount(Bitboard bb) {
 #if defined(_MSC_VER)
-    return static_cast<int>(__popcnt64(bb));
+    // On Windows use the intrinsics provided by MSVC. When targeting x64 we
+    // can take advantage of the 64-bit popcount instruction directly. For
+    // 32-bit builds fall back to two 32-bit operations to cover the full
+    // 64-bit value.
+#   if defined(_M_X64)
+    return static_cast<int>(_mm_popcnt_u64(bb));
+#   else
+    return _mm_popcnt_u32(static_cast<uint32_t>(bb)) +
+           _mm_popcnt_u32(static_cast<uint32_t>(bb >> 32));
+#   endif
+#elif defined(__clang__) || defined(__GNUC__)
+    // GCC/Clang expose a builtin that maps to the appropriate instruction or
+    // an efficient library call depending on the target architecture.
+    return static_cast<int>(__builtin_popcountll(bb));
 #else
-    return __builtin_popcountll(bb);
+    // Generic fallback using the classic Kernighan loop. This will be used for
+    // any other compiler/architecture combination and avoids relying on
+    // non-standard intrinsics.
+    int count = 0;
+    while (bb) {
+        bb &= bb - 1;
+        ++count;
+    }
+    return count;
 #endif
 }
 

--- a/tests/popcount_test.cpp
+++ b/tests/popcount_test.cpp
@@ -1,0 +1,30 @@
+#include "../cpp_chess_engine/BitOps.hpp"
+#include <cassert>
+#include <iostream>
+
+int main() {
+    Bitboard v1 = 0ULL;
+    Bitboard v2 = 0xF0F0F0F0F0F0F0F0ULL; // 32 bits set
+    Bitboard v3 = 0b1011ULL; // 3 bits set
+
+    if (popcount(v1) != 0) {
+        std::cerr << "popcount failed on zero" << std::endl;
+        return 1;
+    }
+    if (popcount(v2) != 32) {
+        std::cerr << "popcount failed on pattern" << std::endl;
+        return 1;
+    }
+    if (popcount(v3) != 3) {
+        std::cerr << "popcount failed on three" << std::endl;
+        return 1;
+    }
+
+#if defined(_MSC_VER)
+    std::cout << "Running MSVC popcount implementation" << std::endl;
+#else
+    std::cout << "Running generic/GNU popcount implementation" << std::endl;
+#endif
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- implement cross-platform `popcount` using MSVC intrinsics on Windows, GCC/Clang builtins on Linux, and a generic fallback
- include `<nmmintrin.h>` to access `_mm_popcnt_u64` and guard with compile-time checks
- add `popcount_test` example to CMake and repository

## Testing
- `g++ -std=c++17 tests/popcount_test.cpp cpp_chess_engine/BitOps.cpp -Icpp_chess_engine -o popcount_test && ./popcount_test`
- `cmake ..` *(fails: unable to fetch SFML from GitHub)*

------
https://chatgpt.com/codex/tasks/task_e_688edb8578a083288cce0342f6c53ece