### PR TITLE
Add portable popcount function and unit test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,3 +23,9 @@ target_include_directories(cpp_chess_engine PRIVATE cpp_chess_engine)
 
 target_link_libraries(cpp_chess_engine PRIVATE sfml-graphics sfml-window sfml-system)
 
+enable_testing()
+
+add_executable(popcount_test tests/popcount_test.cpp cpp_chess_engine/BitOps.cpp)
+target_include_directories(popcount_test PRIVATE cpp_chess_engine)
+add_test(NAME popcount_test COMMAND popcount_test)
+

--- a/cpp_chess_engine/BitOps.cpp
+++ b/cpp_chess_engine/BitOps.cpp
@@ -7,6 +7,7 @@
 #include <bitset>
 #if defined(_MSC_VER)
 #include <intrin.h>
+#include <nmmintrin.h>
 #endif
 
 // Scans the bitboard from least significant bit to most significant bit
@@ -32,12 +33,34 @@ int bitScanForward(Bitboard bb) {
 #endif
 }
 
-// Counts the number of set bits in a bitboard.
+// Counts the number of set bits in a bitboard using the most efficient
+// implementation available for the current platform.
 int popcount(Bitboard bb) {
 #if defined(_MSC_VER)
-    return static_cast<int>(__popcnt64(bb));
+    // On Windows use the intrinsics provided by MSVC. When targeting x64 we
+    // can take advantage of the 64-bit popcount instruction directly. For
+    // 32-bit builds fall back to two 32-bit operations to cover the full
+    // 64-bit value.
+#   if defined(_M_X64)
+    return static_cast<int>(_mm_popcnt_u64(bb));
+#   else
+    return _mm_popcnt_u32(static_cast<uint32_t>(bb)) +
+           _mm_popcnt_u32(static_cast<uint32_t>(bb >> 32));
+#   endif
+#elif defined(__clang__) || defined(__GNUC__)
+    // GCC/Clang expose a builtin that maps to the appropriate instruction or
+    // an efficient library call depending on the target architecture.
+    return static_cast<int>(__builtin_popcountll(bb));
 #else
-    return __builtin_popcountll(bb);
+    // Generic fallback using the classic Kernighan loop. This will be used for
+    // any other compiler/architecture combination and avoids relying on
+    // non-standard intrinsics.
+    int count = 0;
+    while (bb) {
+        bb &= bb - 1;
+        ++count;
+    }
+    return count;
 #endif
 }
 

--- a/cpp_chess_engine/GUIBoard.cpp
+++ b/cpp_chess_engine/GUIBoard.cpp
@@ -2,6 +2,7 @@
 #include "ChessBoard.hpp"
 #include "BitOps.hpp"
 #include <optional>
+#include <variant>
 
 GUIBoard::GUIBoard(ChessBoard& cb) : cb(cb) {
     initialize();  // Additional setup function
@@ -63,6 +64,53 @@ void GUIBoard::createSFMLWindow() {
 
     while (window.isOpen()) {
         // --- Event Handling ---
+#if SFML_VERSION_MAJOR >= 3
+        while (auto eventOpt = window.pollEvent()) {
+            const sf::Event& event = *eventOpt;
+            if (std::holds_alternative<sf::Event::Closed>(event)) {
+                window.close();
+            } else if (const auto* mb = std::get_if<sf::Event::MouseButtonPressed>(&event)) {
+                int col = mb->position.x / cellSize;
+                int row = mb->position.y / cellSize;
+
+                if (mb->button == sf::Mouse::Button::Left) {
+                    // clear any attack highlights on a normal (left) click
+                    attackSourceSquare.reset();
+
+                    if (col >= 0 && col < 8 && row >= 0 && row < 8) {
+                        if (!selectedSquare) {
+                            // select piece if one exists
+                            if (getBoard()[row][col] != '.') {
+                                selectedSquare = { col, row };
+                            }
+                        }
+                        else {
+                            // attempt move
+                            int from_idx = (7 - selectedSquare->y) * 8 + selectedSquare->x;
+                            int to_idx = (7 - row) * 8 + col;
+                            if (cb.validateMove(from_idx, to_idx)) {
+                                cb.movePiece(selectedSquare->y, selectedSquare->x, row, col);
+                                cb.syncBoardWithBitboards();
+                            }
+                            selectedSquare.reset();
+                        }
+                    }
+                }
+                else if (mb->button == sf::Mouse::Button::Right) {
+                    sf::Vector2i clicked{ col, row };
+                    // toggle attack highlight on repeated right-click
+                    if (attackSourceSquare && *attackSourceSquare == clicked) {
+                        attackSourceSquare.reset();
+                    }
+                    else {
+                        attackSourceSquare = clicked;
+                    }
+                    // also clear any normal selection
+                    selectedSquare.reset();
+                }
+            }
+        }
+#else
         sf::Event event;
         while (window.pollEvent(event)) {
             if (event.type == sf::Event::Closed) {
@@ -109,6 +157,7 @@ void GUIBoard::createSFMLWindow() {
                 }
             }
         }
+#endif
 
         // --- Rendering ---
         window.clear();

--- a/cpp_chess_engine/RookValidator.cpp
+++ b/cpp_chess_engine/RookValidator.cpp
@@ -80,7 +80,7 @@ Bitboard findMagic(int square, int relevantBits, bool isRook) {
         std::fill(used.begin(), used.end(), 0ULL);
         bool collision = false;
         for (size_t i = 0; i < occupancies.size(); i++) {
-            int magicIndex = (occupancies[i] * magicCandidate) >> (64 - relevantBits);
+            std::size_t magicIndex = static_cast<std::size_t>((occupancies[i] * magicCandidate) >> (64 - relevantBits));
             if (used[magicIndex] == 0ULL) {
                 used[magicIndex] = attacks[i];
             }
@@ -118,7 +118,7 @@ void RookValidator::initRookMagics() {
         m.magic = findMagic(square, relevantBits, true);
         for (int index = 0; index < occupancyVariations; index++) {
             Bitboard occupancy = setOccupancy(index, relevantBits, m.mask);
-            int magicIndex = (occupancy * m.magic) >> m.shift;
+            std::size_t magicIndex = static_cast<std::size_t>((occupancy * m.magic) >> m.shift);
             m.attacks[magicIndex] = rookAttacksOnTheFly(square, occupancy);
         }
     }

--- a/tests/popcount_test.cpp
+++ b/tests/popcount_test.cpp
@@ -1,0 +1,30 @@
+#include "../cpp_chess_engine/BitOps.hpp"
+#include <cassert>
+#include <iostream>
+
+int main() {
+    Bitboard v1 = 0ULL;
+    Bitboard v2 = 0xF0F0F0F0F0F0F0F0ULL; // 32 bits set
+    Bitboard v3 = 0b1011ULL; // 3 bits set
+
+    if (popcount(v1) != 0) {
+        std::cerr << "popcount failed on zero" << std::endl;
+        return 1;
+    }
+    if (popcount(v2) != 32) {
+        std::cerr << "popcount failed on pattern" << std::endl;
+        return 1;
+    }
+    if (popcount(v3) != 3) {
+        std::cerr << "popcount failed on three" << std::endl;
+        return 1;
+    }
+
+#if defined(_MSC_VER)
+    std::cout << "Running MSVC popcount implementation" << std::endl;
+#else
+    std::cout << "Running generic/GNU popcount implementation" << std::endl;
+#endif
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- implement cross-platform `popcount` using MSVC intrinsics on Windows, GCC/Clang builtins on Linux, and a generic fallback
- include `<nmmintrin.h>` to access `_mm_popcnt_u64` and guard with compile-time checks
- add `popcount_test` example to CMake and repository
- support both SFML 2.x and 3.x event APIs for GUI, and fix MSVC size-cast warnings

## Testing
- `g++ -std=c++17 tests/popcount_test.cpp cpp_chess_engine/BitOps.cpp -Icpp_chess_engine -o popcount_test && ./popcount_test`
- `cmake -S . -B build` *(fails: unable to clone SFML from GitHub)*

------
https://chatgpt.com/codex/tasks/task_e_688edb8578a083288cce0342f6c53ece