### PR TITLE
Add SAN and PGN parsing utilities

### DIFF
--- a/cpp_chess_engine/ChessBoard.cpp
+++ b/cpp_chess_engine/ChessBoard.cpp
@@ -1492,11 +1492,13 @@ bool ChessBoard::validatePGN(const std::string& pgnPath) {
     bool allCorrect = true;
     std::string line;
     std::string expectedResult;
+    std::string currentGameId;
     std::vector<std::string> moveTokens;
 
     auto processGame = [&]() {
         if (moveTokens.empty()) return;
         ChessBoard game; // start from initial position
+        size_t moveIndex = 0;
         for (size_t i = 0; i < moveTokens.size(); ++i) {
             std::string tok = moveTokens[i];
             if (tok.find('.') != std::string::npos) continue; // skip move numbers
@@ -1504,14 +1506,25 @@ bool ChessBoard::validatePGN(const std::string& pgnPath) {
             if (tok.size() == 1 && i + 1 < moveTokens.size()) {
                 tok += moveTokens[++i];
             }
-            game.movePieceSAN(tok);
+            ++moveIndex;
+            if (!game.movePieceSAN(tok)) {
+                std::cerr << "Game " << currentGameId
+                          << " failed at move " << moveIndex
+                          << " (" << tok << ")" << std::endl;
+                allCorrect = false;
+                break;
+            }
         }
         std::string actual = game.get_game_results();
         if (actual != expectedResult) {
+            std::cerr << "Game " << currentGameId
+                      << " result mismatch: expected " << expectedResult
+                      << " but got " << actual << std::endl;
             allCorrect = false;
         }
         moveTokens.clear();
         expectedResult.clear();
+        currentGameId.clear();
     };
 
     while (std::getline(file, line)) {
@@ -1525,6 +1538,11 @@ bool ChessBoard::validatePGN(const std::string& pgnPath) {
                 size_t second = line.find('"', first + 1);
                 if (first != std::string::npos && second != std::string::npos)
                     expectedResult = line.substr(first + 1, second - first - 1);
+            } else if (line.rfind("[GameId", 0) == 0) {
+                size_t first = line.find('"');
+                size_t second = line.find('"', first + 1);
+                if (first != std::string::npos && second != std::string::npos)
+                    currentGameId = line.substr(first + 1, second - first - 1);
             }
             continue;
         }

--- a/cpp_chess_engine/ChessBoard.cpp
+++ b/cpp_chess_engine/ChessBoard.cpp
@@ -6,6 +6,9 @@
 #include "BishopValidator.hpp"
 #include "Constants.hpp"
 #include "BitOps.hpp"
+#include <fstream>
+#include <sstream>
+#include <vector>
 
 
 RookValidator rookValidator;
@@ -1386,6 +1389,153 @@ bool ChessBoard::movePieceUCI(const std::string& move) {
 	if (promotion != '0') return movePiece(fromRow, fromCol, toRow, toCol, promotion);
 	else
     return movePiece(fromRow, fromCol, toRow, toCol);
+}
+
+bool ChessBoard::movePieceSAN(const std::string& sanMove) {
+    std::string move = sanMove;
+    syncBoardWithBitboards();
+    // Remove annotations like +, #, !, ?
+    while (!move.empty() && (move.back() == '+' || move.back() == '#' || move.back() == '!' || move.back() == '?')) {
+        move.pop_back();
+    }
+
+    // Handle castling
+    if (move == "O-O" || move == "0-0") {
+        return whiteToMove ? movePieceUCI("e1g1") : movePieceUCI("e8g8");
+    }
+    if (move == "O-O-O" || move == "0-0-0") {
+        return whiteToMove ? movePieceUCI("e1c1") : movePieceUCI("e8c8");
+    }
+
+    char promotion = '0';
+    size_t eqPos = move.find('=');
+    if (eqPos != std::string::npos && eqPos + 1 < move.size()) {
+        promotion = std::tolower(move[eqPos + 1]);
+        move = move.substr(0, eqPos);
+    }
+
+    size_t capturePos = move.find('x');
+    bool isCapture = capturePos != std::string::npos;
+
+    // Determine piece type
+    char piece = 'P';
+    size_t idx = 0;
+    if (!move.empty() && std::isupper(move[0]) && move[0] != 'O') {
+        piece = move[0];
+        idx = 1;
+    }
+
+    // Destination square (last two characters)
+    if (move.size() < 2) return false;
+    std::string dest = move.substr(move.size() - 2, 2);
+    int toCol = dest[0] - 'a';
+    int toRow = '8' - dest[1];
+    int destIndex = get_bitindex(toRow, toCol);
+    Bitboard destMask = 1ULL << destIndex;
+
+    // Disambiguation between piece char and destination/capture
+    size_t disambEnd = (isCapture ? capturePos : move.size() - 2);
+    std::string disamb = move.substr(idx, disambEnd - idx);
+
+    auto moves = getAllMoves();
+    Bitboard originCandidate = 0ULL;
+    int fromRow = 0, fromCol = 0;
+
+    for (const auto& kv : moves) {
+        Bitboard origin = kv.first;
+        Bitboard destinations = kv.second;
+        if (!(destinations & destMask)) continue;
+        int originIndex = bitScanForward(origin);
+        int row = 7 - (originIndex / 8);
+        int col = originIndex % 8;
+        char boardPiece = board[row][col];
+        char upperPiece = std::toupper(boardPiece);
+        if (piece == 'P') {
+            if (upperPiece != 'P') continue;
+        } else {
+            if (upperPiece != piece) continue;
+        }
+
+        bool match = true;
+        if (!disamb.empty()) {
+            if (disamb.size() == 2) {
+                if (col != disamb[0] - 'a' || row != '8' - disamb[1]) match = false;
+            } else if (std::isdigit(disamb[0])) {
+                if (row != '8' - disamb[0]) match = false;
+            } else {
+                if (col != disamb[0] - 'a') match = false;
+            }
+        }
+        if (!match) continue;
+
+        originCandidate = origin;
+        fromRow = row;
+        fromCol = col;
+        break; // Assume SAN uniquely identifies a move
+    }
+
+    if (originCandidate == 0ULL) {
+        std::cerr << "Failed to parse SAN move: " << sanMove << std::endl;
+        return false;
+    }
+
+    if (promotion != '0') return movePiece(fromRow, fromCol, toRow, toCol, promotion);
+    return movePiece(fromRow, fromCol, toRow, toCol);
+}
+
+bool ChessBoard::validatePGN(const std::string& pgnPath) {
+    std::ifstream file(pgnPath);
+    if (!file.is_open()) {
+        std::cerr << "Unable to open PGN file: " << pgnPath << std::endl;
+        return false;
+    }
+    bool allCorrect = true;
+    std::string line;
+    std::string expectedResult;
+    std::vector<std::string> moveTokens;
+
+    auto processGame = [&]() {
+        if (moveTokens.empty()) return;
+        ChessBoard game; // start from initial position
+        for (size_t i = 0; i < moveTokens.size(); ++i) {
+            std::string tok = moveTokens[i];
+            if (tok.find('.') != std::string::npos) continue; // skip move numbers
+            if (tok == "1-0" || tok == "0-1" || tok == "1/2-1/2" || tok == "*") continue;
+            if (tok.size() == 1 && i + 1 < moveTokens.size()) {
+                tok += moveTokens[++i];
+            }
+            game.movePieceSAN(tok);
+        }
+        std::string actual = game.get_game_results();
+        if (actual != expectedResult) {
+            allCorrect = false;
+        }
+        moveTokens.clear();
+        expectedResult.clear();
+    };
+
+    while (std::getline(file, line)) {
+        if (line.empty()) {
+            processGame();
+            continue;
+        }
+        if (line[0] == '[') {
+            if (line.rfind("[Result", 0) == 0) {
+                size_t first = line.find('"');
+                size_t second = line.find('"', first + 1);
+                if (first != std::string::npos && second != std::string::npos)
+                    expectedResult = line.substr(first + 1, second - first - 1);
+            }
+            continue;
+        }
+        std::stringstream ss(line);
+        std::string token;
+        while (ss >> token) {
+            moveTokens.push_back(token);
+        }
+    }
+    processGame();
+    return allCorrect;
 }
 
 

--- a/cpp_chess_engine/ChessBoard.cpp
+++ b/cpp_chess_engine/ChessBoard.cpp
@@ -1510,7 +1510,9 @@ bool ChessBoard::validatePGN(const std::string& pgnPath) {
             if (!game.movePieceSAN(tok)) {
                 std::cerr << "Game " << currentGameId
                           << " failed at move " << moveIndex
-                          << " (" << tok << ")" << std::endl;
+                          << " (" << tok << ")"  
+                          << "FEN: " 
+                          << game.getString() << std::endl;
                 allCorrect = false;
                 break;
             }

--- a/cpp_chess_engine/ChessBoard.hpp
+++ b/cpp_chess_engine/ChessBoard.hpp
@@ -96,6 +96,8 @@ public:
     void syncBoardWithBitboards();
     int BoardCoordToCellIndex(const std::string& coord) const;
     bool movePieceUCI(const std::string& move);
+    bool movePieceSAN(const std::string& sanMove);
+    bool validatePGN(const std::string& pgnPath);
 
     // Public helper to convert board coordinates to a bit index.
     int get_bitindex(int row, int col) ;

--- a/cpp_chess_engine/main.cpp
+++ b/cpp_chess_engine/main.cpp
@@ -1,5 +1,6 @@
 #include <iostream>
 #include <string>
+#include <filesystem>
 
 // ANSI escape codes for colors.
 #define RESET "\033[0m"
@@ -86,10 +87,35 @@ void tests() {
     std::cout << "All tests executed." << std::endl;
 }
 
+// Run PGN validation on all sample PGN files before launching the GUI.
+void runPGNTests() {
+    namespace fs = std::filesystem;
+    bool allPassed = true;
+    for (const auto& entry : fs::directory_iterator("sample_pgns")) {
+        if (entry.path().extension() == ".pgn") {
+            ChessBoard validator;
+            bool ok = validator.validatePGN(entry.path().string());
+            std::cout << entry.path().filename().string() << ": "
+                      << (ok ? "passed" : "failed") << std::endl;
+            if (!ok) {
+                allPassed = false;
+            }
+        }
+    }
+    if (allPassed) {
+        std::cout << "All PGN tests passed." << std::endl;
+    } else {
+        std::cout << "Some PGN tests failed." << std::endl;
+    }
+}
+
 int main(int argc, char** argv) {
+    // Run PGN tests before showing the GUI board.
+    runPGNTests();
+
     // Initialize the FEN string for the standard starting position.
     //tests();
-    
+
     std::string fen = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 0";
     //fen = "rn1qk2r/pppPpppp/6bn/2b5/8/8/PPPP1PPP/RNBQKBNR w KQkq - 0 5";
     ChessBoard cb(fen);


### PR DESCRIPTION
## Summary
- add `movePieceSAN` to interpret SAN chess moves
- add `validatePGN` to replay games from PGN and compare recorded results

## Testing
- `g++ -std=c++17 -I. -Icpp_chess_engine /tmp/test_san.cpp cpp_chess_engine/ChessBoard.cpp cpp_chess_engine/BitOps.cpp cpp_chess_engine/BishopValidator.cpp cpp_chess_engine/KingValidator.cpp cpp_chess_engine/PawnValidator.cpp cpp_chess_engine/RookValidator.cpp cpp_chess_engine/KnightValidator.cpp -o /tmp/test_san`
- `/tmp/test_san` *(fails: PGN validation: fail)*

------
https://chatgpt.com/codex/tasks/task_e_68c20ac64bc483288b1b7303b455a1b5