### PR TITLE
Add FEN move tests and integrate with test runner

### DIFF
--- a/cpp_chess_engine/FENTestRunner.cpp
+++ b/cpp_chess_engine/FENTestRunner.cpp
@@ -1,0 +1,64 @@
+#include "FENTestRunner.hpp"
+
+#include <iostream>
+#include <vector>
+
+#include "ChessBoard.hpp"
+
+namespace {
+struct FENTestCase {
+    std::string fen;
+    std::string sanMove;
+    bool shouldFail;
+    std::string description;
+};
+}
+
+bool runFENMoveTest(const std::string& fen, const std::string& sanMove, bool shouldFail)
+{
+    ChessBoard board(fen);
+
+    bool moveAccepted = board.movePieceSAN(sanMove);
+    bool passed = shouldFail ? !moveAccepted : moveAccepted;
+
+    std::cout << "FEN move test (" << (shouldFail ? "expect fail" : "expect pass")
+              << "): " << sanMove << " | " << fen << " -> "
+              << (passed ? "passed" : "failed") << std::endl;
+
+    return passed;
+}
+
+bool runFENTests()
+{
+    const std::vector<FENTestCase> testCases = {
+        {"rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1", "e4", false,
+         "Standard opening pawn advance"},
+        {"rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1", "Bh5", true,
+         "Bishop cannot jump pawns on opening rank"},
+        {"r3k2r/8/8/8/8/8/8/R3K2R w KQkq - 0 1", "O-O", false,
+         "Castling is available when paths are clear"},
+        {"r3k2r/8/8/8/8/8/4r3/R3K2R w KQkq - 0 1", "O-O", true,
+         "Castling through check should be rejected"},
+        {"4k3/8/8/3p4/4P3/8/8/4K3 w - - 0 1", "exd5", false,
+         "Simple pawn capture"},
+        {"4k3/8/8/3p4/4P3/8/8/4K3 w - - 0 1", "exd6", true,
+         "Pawn cannot capture empty square"},
+    };
+
+    bool allPassed = true;
+    for (const auto& testCase : testCases) {
+        bool passed = runFENMoveTest(testCase.fen, testCase.sanMove, testCase.shouldFail);
+        if (!passed) {
+            allPassed = false;
+            std::cout << "  Description: " << testCase.description << std::endl;
+        }
+    }
+
+    if (allPassed) {
+        std::cout << "All FEN move tests passed." << std::endl;
+    } else {
+        std::cout << "Some FEN move tests failed." << std::endl;
+    }
+
+    return allPassed;
+}

--- a/cpp_chess_engine/FENTestRunner.hpp
+++ b/cpp_chess_engine/FENTestRunner.hpp
@@ -1,0 +1,13 @@
+#ifndef FEN_TEST_RUNNER_HPP
+#define FEN_TEST_RUNNER_HPP
+
+#include <string>
+
+// Validate a single SAN move against a provided FEN position. When shouldFail is true,
+// the function expects the move to be rejected by the validator.
+bool runFENMoveTest(const std::string& fen, const std::string& sanMove, bool shouldFail);
+
+// Execute the built-in suite of FEN/move validation tests.
+bool runFENTests();
+
+#endif // FEN_TEST_RUNNER_HPP

--- a/cpp_chess_engine/pgn_tester_main.cpp
+++ b/cpp_chess_engine/pgn_tester_main.cpp
@@ -1,6 +1,7 @@
 #include <filesystem>
 #include <iostream>
 
+#include "FENTestRunner.hpp"
 #include "PGNTestRunner.hpp"
 
 int main(int argc, char** argv)
@@ -10,10 +11,15 @@ int main(int argc, char** argv)
         directory = argv[1];
     }
 
-    bool passed = runPGNTests(directory);
-    if (!passed) {
+    bool pgnPassed = runPGNTests(directory);
+    if (!pgnPassed) {
         std::cerr << "PGN validation failed." << std::endl;
     }
 
-    return passed ? 0 : 1;
+    bool fenPassed = runFENTests();
+    if (!fenPassed) {
+        std::cerr << "FEN move validation failed." << std::endl;
+    }
+
+    return (pgnPassed && fenPassed) ? 0 : 1;
 }


### PR DESCRIPTION
## Summary
- add a dedicated FEN test runner to exercise SAN move validation against specific positions
- update the command-line test runner to execute both PGN validation and the new FEN move suite

## Testing
- cmake -S . -B build -DBUILD_GUI=OFF -DBUILD_PGN_TEST_RUNNER=ON
- cmake --build build --target pgn_tester
- ./build/pgn_tester

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692724628ee88328a0149a9258b9e89c)