### PR TITLE
Windows build script: consolidate copying of SFML DLLs and piece images; document behavior in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,12 +23,13 @@ sudo apt install libudev-dev
 .\scripts\build_windows.ps1
 ```
 
-After building, ensure the SFML debug or release DLLs are next to the
-generated executable (e.g. copy the contents of `C:\SFML-3.0.0\bin`
-into your `x64/Debug` or `x64/Release` directory) or add that `bin`
-directory to your `PATH`. Without these runtime libraries, Windows will
-report missing `sfml-graphics-*-3.dll` files when launching the
-application.
+The build script also copies SFML runtime DLLs and piece images into common
+output directories (`build`, `out/build/x64-*`, and `x64/*`) so the executable
+can be launched from Visual Studio CMake mode or legacy solution mode.
+
+If Windows still reports a missing `sfml-graphics-*.dll` file, verify your
+startup target points at one of those output directories, or add the SFML
+runtime folder to your `PATH`.
 
 ## Running PGN validation without the GUI
 

--- a/scripts/build_windows.ps1
+++ b/scripts/build_windows.ps1
@@ -1,35 +1,63 @@
+$ErrorActionPreference = 'Stop'
+
 cmake -S . -B build
 cmake --build build
 
-# Copy SFML runtime libraries next to the built executable(s)
+function Copy-ToExistingDirs {
+    param(
+        [Parameter(Mandatory=$true)]
+        [string[]]$Destinations,
+        [Parameter(Mandatory=$true)]
+        [scriptblock]$CopyAction
+    )
+
+    foreach ($destination in $Destinations) {
+        if (Test-Path $destination) {
+            & $CopyAction $destination
+        }
+    }
+}
+
+# Copy SFML runtime libraries next to executable output directories.
 $sfmlRoot = "build/_deps/sfml-build"
 $sfmlBin = Join-Path $sfmlRoot "bin"
 $sfmlLib = Join-Path $sfmlRoot "lib"
+$sfmlDlls = @()
 
 if (Test-Path $sfmlBin) {
     $sfmlDlls = Get-ChildItem -Path $sfmlBin -Filter '*.dll' -Recurse
-} elseif (Test-Path $sfmlLib) {
+}
+
+if ($sfmlDlls.Count -eq 0 -and (Test-Path $sfmlLib)) {
     $sfmlDlls = Get-ChildItem -Path $sfmlLib -Filter '*.dll' -Recurse
 }
 
-if ($sfmlDlls) {
-    $sfmlDlls | Copy-Item -Destination build -Force
-    if (Test-Path build/Debug) {
-        $sfmlDlls | Copy-Item -Destination build/Debug -Force
+$outputDirs = @(
+    'build',
+    'build/Debug',
+    'build/Release',
+    'out/build/x64-Debug',
+    'out/build/x64-Release',
+    'x64/Debug',
+    'x64/Release'
+)
+
+if ($sfmlDlls.Count -gt 0) {
+    Copy-ToExistingDirs -Destinations $outputDirs -CopyAction {
+        param($destination)
+        $sfmlDlls | Copy-Item -Destination $destination -Force
     }
-    if (Test-Path build/Release) {
-        $sfmlDlls | Copy-Item -Destination build/Release -Force
-    }
+} else {
+    Write-Warning "No SFML DLLs were found under '$sfmlBin' or '$sfmlLib'."
 }
 
-# Copy piece images into the build output so the executable can load them
+# Copy piece images into executable output directories.
 $pieceSrc = "cpp_chess_engine/piece_pngs"
 if (Test-Path $pieceSrc) {
-    Copy-Item $pieceSrc build -Recurse -Force
-    if (Test-Path build/Debug) {
-        Copy-Item $pieceSrc build/Debug -Recurse -Force
+    Copy-ToExistingDirs -Destinations $outputDirs -CopyAction {
+        param($destination)
+        Copy-Item $pieceSrc $destination -Recurse -Force
     }
-    if (Test-Path build/Release) {
-        Copy-Item $pieceSrc build/Release -Recurse -Force
-    }
+} else {
+    Write-Warning "Piece image directory '$pieceSrc' was not found."
 }


### PR DESCRIPTION
### Motivation

- Ensure SFML runtime DLLs and piece images are copied into common Visual Studio/CMake output directories so the executable can be launched from VS build modes without missing-DLL errors.
- Improve robustness and clarity of the Windows build script by centralizing copy logic and emitting warnings when expected artifacts are not found.

### Description

- Add `Copy-ToExistingDirs` helper in `scripts/build_windows.ps1` and use it to copy SFML DLLs and piece images into multiple output directories instead of copying to individual paths inline.
- Detect SFML DLLs under `build/_deps/sfml-build/bin` or `.../lib` and copy them to `build`, `build/Debug`, `build/Release`, `out/build/x64-Debug`, `out/build/x64-Release`, `x64/Debug`, and `x64/Release`, emitting a warning if none are found.
- Set `$ErrorActionPreference = 'Stop'` to fail early on errors and keep the existing `cmake -S . -B build` and `cmake --build build` calls.
- Update `README.md` to document that the build script copies SFML runtime DLLs and piece images into common output directories and to advise verifying the startup target or `PATH` if a `sfml-graphics-*.dll` is still reported missing.

### Testing

- Ran the Windows build script `scripts/build_windows.ps1` (which invokes `cmake -S . -B build` and `cmake --build build`) on a Windows environment and observed that SFML DLLs and piece images were copied into detected output directories (success).
- No unit tests or CI configurations were changed by this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a624fcc334832883b03f4cdf15677d)